### PR TITLE
fix: correct French translation in items_fr.json

### DIFF
--- a/app/i18n/translations/items_fr.json
+++ b/app/i18n/translations/items_fr.json
@@ -206,7 +206,7 @@
   "Very Comfortable Pillow": "Oreiller Très Confortable",
   "Volcanic Rock": "Roche Volcanique",
   "Voltage Converter": "Convertisseur de Tension",
-  "Wasp Driver": "Pilote Wasp",
+  "Wasp Driver": "Pilote de guêpe",
   "Water Filter": "Filtre à Eau",
   "Water Pump": "Pompe à Eau",
   "Wires": "Câbles",


### PR DESCRIPTION
Fix incorrect French translation:
"Pilote de wasp" → "Pilote de guêpe"
<img width="274" height="103" alt="image" src="https://github.com/user-attachments/assets/cee1860a-5d1d-4ffe-9ff2-7c4a31377d3a" />
